### PR TITLE
add simple elf parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 capstone >= 4.0.1
 pefile >= 2019.4.18
+pyelftools
 pyyaml

--- a/rop3/binaries/elf.py
+++ b/rop3/binaries/elf.py
@@ -1,0 +1,64 @@
+'''
+This file is part of rop3 (https://github.com/reverseame/rop3).
+
+rop3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+rop3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with rop3. If not, see <https://www.gnu.org/licenses/>.
+'''
+
+import capstone
+import io
+
+from elftools.elf.elffile import ELFFile, ELFError
+
+import rop3.binary as binary
+
+SHF_EXECINSTR = 0x4
+
+
+class ELF:
+    ''' Parses Executable and Linkable Format (ELF) '''
+
+    def __init__(self, data, base):
+        try:
+            file = io.BytesIO(data)
+            self._elf = ELFFile(file)
+            (self._arch, self._arch_mode) = self._parse_arch()
+        except ELFError as exc:
+            raise binary.BinaryException(str(exc)) from exc
+
+    def _parse_arch(self):
+        if self._elf.header.e_machine in ['EM_X86_64', 'EM_386']:
+            if self._elf.elfclass == 32:
+                return (capstone.CS_ARCH_X86, capstone.CS_MODE_32)
+            elif self._elf.elfclass == 64:
+                return (capstone.CS_ARCH_X86, capstone.CS_MODE_64)
+        raise binary.BinaryException(
+            'ELF: Unsupported architecture type')
+
+    def get_exec_sections(self):
+        ret = []
+
+        for sec in self._elf.iter_sections():
+            ''' SHF_EXECINSTR means section contains executable code '''
+            if sec.header.sh_flags & SHF_EXECINSTR:
+                ret.append({
+                    'vaddr': sec.header.sh_addr,
+                    'opcodes': sec.data()
+                })
+        return ret
+
+    def get_arch(self):
+        return self._arch
+
+    def get_arch_mode(self):
+        return self._arch_mode

--- a/rop3/binary.py
+++ b/rop3/binary.py
@@ -18,6 +18,7 @@ along with rop3. If not, see <https://www.gnu.org/licenses/>.
 import os
 
 import rop3.debug as debug
+import rop3.binaries.elf as elf
 import rop3.binaries.pe as pe
 
 class Binary:
@@ -40,6 +41,8 @@ class Binary:
         ''' MS-DOS Stub '''
         if self.raw_data[:2] == b'\x4d\x5a':    # MZ
             return pe.PE(self.raw_data, base)
+        elif self.raw_data[:2] == b'\x7f\x45':
+            return elf.ELF(self.raw_data, base)
         else:
             raise BinaryException(f'{self.filename}: Format file not supported')
 


### PR DESCRIPTION
This is a simple attempt at parsing ELF file like the PE file
```
$ file ../pclubppt/target
../pclubppt/target: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=......, not stripped
$ python rop3.py --binary ../pclubppt/target
[target @ 0x0000000040075f]: add bl, dh ; ret (x3)
[target @ 0x000000004009ed]: add byte ptr [rax], al ; add bl, dh ; ret
[target @ 0x00000000400796]: add byte ptr [rax], al ; pop rbp ; ret
[target @ 0x0000000040075e]: add byte ptr [rax], al ; ret (x3)
[target @ 0x00000000400795]: add byte ptr [rax], r8b ; pop rbp ; ret
[target @ 0x0000000040075d]: add byte ptr [rax], r8b ; ret (x2)
[target @ 0x000000004007f7]: add byte ptr [rcx], al ; pop rbp ; ret
[target @ 0x00000000400673]: add esp, 8 ; ret (x2)
[target @ 0x00000000400672]: add rsp, 8 ; ret (x2)
[target @ 0x00000000400902]: dec ecx ; ret
[target @ 0x000000004009cc]: fmul qword ptr [rax - 0x7d] ; ret
[target @ 0x00000000400903]: leave ; ret
[target @ 0x000000004007d5]: nop dword ptr [rax] ; pop rbp ; ret
[target @ 0x000000004009e0]: pop r14 ; pop r15 ; ret
[target @ 0x000000004009e2]: pop r15 ; ret
[target @ 0x00000000400798]: pop rbp ; ret (x4)
[target @ 0x00000000400979]: pop rbx ; pop rbp ; ret
[target @ 0x000000004009e3]: pop rdi ; ret
[target @ 0x000000004009e1]: pop rsi ; pop r15 ; ret
[target @ 0x00000000400676]: ret (x16)
[target @ 0x00000000400978]: sbb byte ptr [rbx + 0x5d], bl ; ret
$ file ../target1
../target1: ELF 32-bit LSB executable, Intel 80386, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=....., not stripped
$ python rop3.py --binary ../target1
[target1 @ 0x807a250]: aaa ; add byte ptr [eax], al ; ret (x3)
[target1 @ 0x809edab]: aam 0x5b ; ret
[target1 @ 0x8088b02]: adc al, 0x18 ; pop ebx ; pop esi ; ret
[target1 @ 0x805c5f7]: adc al, 0x24 ; ret
[target1 @ 0x809b61e]: adc al, 0x29 ; ret
....
```