### PR TITLE
Avoid canary bytes in gadget addresses on dedup (#5) + QoL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Now, you can install dependencies in [requirements.txt](requirements.txt):
 
 ```
 usage: rop3.py [-h] [-v] [--depth <bytes>] [--all] [--rop | --no-rop] [--retf | --no-retf] [--jop | --no-jop] [--allow-undeterministic-gadgets] [--allow-complex-memory-ops] [--verbose]
-               [--binary <file> [<file> ...]] [--badchar <hex> [<hex> ...]] [--base <hex> [<hex> ...]] [--op <op>] [--dst <reg>] [--src <reg>] [--ropchain <file>]
+               [--binary <file> [<file> ...]] [--badchar <hex> [<hex> ...]] [--keep-canary-address] [--base <hex> [<hex> ...]] [--op <op>] [--dst <reg>] [--src <reg>] [--ropchain <file>]
                [--exhaustive | --no-exhaustive]
 
 This tool allows you to search for gadgets, operations, and ROP chains using a backtracking algorithm in a tree-like structure
@@ -56,6 +56,8 @@ options:
                         specify a list of binary path files to analyze
   --badchar <hex> [<hex> ...]
                         specify a list of chars to avoid in gadget address
+  --keep-canary-address
+                        do not prefer canary-free addresses (0x00, 0x0a, 0x0d, 0xff) when discarding duplicate gadgets
   --base <hex> [<hex> ...]
                         specify a base address to relocate binary files (it may take a while). When you specify more than one base address, you need to provide one address for each binary
   --op <op>             search for operation

--- a/rop3/archs/x86_arch.py
+++ b/rop3/archs/x86_arch.py
@@ -45,6 +45,15 @@ REG_ALIASES: dict[str, tuple[str, int]] = {
     for alias, size in info['sub'] + [(canon, info['bytes'])]
 }
 
+# 'rax' -> {8: 'rax', 4: 'eax'},  'r8' -> {8: 'r8', 4: 'r8d'}
+REG_BY_WIDTH: dict[str, dict[int, str]] = {
+    canon: {
+        info['bytes']: canon,
+        **{size: name for name, size in info['sub'] if size in (4, 8)},
+    }
+    for canon, info in REGS.items()
+}
+
 MNEMONIC_PREFIXES: tuple[str, ...] = (
     'notrack', 'bnd',
 )
@@ -177,11 +186,17 @@ class X86_Architecture(Architecture):
                 return True
         return False
 
+    @property
+    def _canonical_width(self) -> int:
+        """Register width (in bytes) used to display/normalize register names"""
+        return 4
+
     def normalize_reg(self, name: str) -> str:
         entry = REG_ALIASES.get(str(name))
-        if entry:
-            return entry[0]
-        return str(name)
+        if not entry:
+            return str(name)
+        canon = entry[0]
+        return REG_BY_WIDTH.get(canon, {}).get(self._canonical_width, canon)
 
     def is_valid_abstract_reg(self, name: str | int) -> bool:
         """
@@ -196,6 +211,10 @@ class X64_Architecture(X86_Architecture):
     @property
     def mode(self):
         return capstone.CS_MODE_64
+
+    @property
+    def _canonical_width(self) -> int:
+        return 8
 
     @property
     def sp(self) -> str:

--- a/rop3/args.py
+++ b/rop3/args.py
@@ -39,6 +39,7 @@ class ArgumentParser:
         self.argparser.add_argument('--verbose', action='store_true', default=False, help='show progress information (gadget counts, combinations)')
         self.argparser.add_argument('--binary', type=str, metavar='<file>', nargs='+', help='specify a list of binary path files to analyze')
         self.argparser.add_argument('--badchar', type=str, metavar='<hex>', nargs='+', help='specify a list of chars to avoid in gadget address')
+        self.argparser.add_argument('--keep-canary-address', action='store_true', default=False, help='do not prefer canary-free addresses (0x00, 0x0a, 0x0d, 0xff) when discarding duplicate gadgets')
         self.argparser.add_argument('--base', type=str, metavar='<hex>', nargs='+', help='specify a base address to relocate binary files (it may take a while). When you specify more than one base address, you need to provide one address for each binary')
         self.argparser.add_argument('--op', type=str, metavar='<op>', help='search for operation')
         self.argparser.add_argument('--dst', type=str, metavar='<reg>', help='specify a destination register for the operation')
@@ -75,6 +76,8 @@ class ArgumentParser:
             flags |= gadfinder.ALLOW_UNDETERMINISTIC
         if args.allow_complex_memory_ops:
             flags |= gadfinder.ALLOW_COMPLEX_MEM
+        if not args.keep_canary_address:
+            flags |= gadfinder.AVOID_CANARY
 
         namespace['flags'] = flags
 

--- a/rop3/binaries/macho.py
+++ b/rop3/binaries/macho.py
@@ -21,7 +21,8 @@ import io
 from macholib.MachO import MachO as _MachO
 from macholib.mach_o import (
     LC_SEGMENT, LC_SEGMENT_64,
-    CPU_TYPE_NAMES
+    CPU_TYPE_NAMES,
+    S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS
 )
 
 import rop3.binary as binary
@@ -29,6 +30,7 @@ import rop3.binary as binary
 from rop3.archs.x86_arch import X86_Architecture, X64_Architecture
 
 VM_PROT_EXECUTE = 0x04
+S_INSTRUCTION_ATTRS = S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS
 
 class MachO:
     def __init__(self, data, base):
@@ -44,16 +46,17 @@ class MachO:
             self._macho.load(self._file)
         except Exception as exc:
             raise binary.BinaryException(str(exc)) from exc
-        # Some binaries include many headers
+        # Fat binaries carry several headers; pick the first supported slice
+        # (do not commit to a header until its architecture is recognised)
         self._header = None
+        self._arch = None
         for header in self._macho.headers:
             arch = CPU_TYPE_NAMES.get(header.header.cputype)
-            self._header = header
             if arch == "x86_64":
-                self._arch = X64_Architecture()
+                self._header, self._arch = header, X64_Architecture()
                 break
             elif arch == "i386":
-                self._arch = X86_Architecture()
+                self._header, self._arch = header, X86_Architecture()
                 break
         if not self._header:
             raise binary.BinaryException(
@@ -65,15 +68,19 @@ class MachO:
             if lc.cmd in (LC_SEGMENT, LC_SEGMENT_64):
                 if cmd.initprot & VM_PROT_EXECUTE:
                     for section in data:
-                        sec_name = section.sectname.decode('utf-8').strip('\x00')
-                        if sec_name == '__text':
-                            offset = self._header.offset
-                            self._file.seek(offset + section.offset)
-                            section_data = self._file.read(section.size)
-                            ret.append({
-                                'vaddr': section.addr,
-                                'opcodes': section_data
-                            })
+                        ''' Scan every code section (e.g. __text, __stubs,
+                            __stub_helper), not just __text. Skip data
+                            sections living in the executable segment
+                            (e.g. __const, __cstring, __unwind_info). '''
+                        if not section.flags & S_INSTRUCTION_ATTRS:
+                            continue
+                        offset = self._header.offset
+                        self._file.seek(offset + section.offset)
+                        section_data = self._file.read(section.size)
+                        ret.append({
+                            'vaddr': section.addr,
+                            'opcodes': section_data
+                        })
         return ret
 
     def get_arch(self):

--- a/rop3/gadfinder.py
+++ b/rop3/gadfinder.py
@@ -26,7 +26,14 @@ ROP = 4
 RETF = 8
 ALLOW_UNDETERMINISTIC = 16
 ALLOW_COMPLEX_MEM = 32
+AVOID_CANARY = 64
 
+''' Terminator canary bytes to avoid in gadget addresses by default:
+    0x00 (string terminator for strcpy() and alike), 0x0a and 0x0d (line
+    terminators for gets() and alike) and 0xff (EOF). See issue #5. '''
+CANARY_BYTES = (0x00, 0x0a, 0x0d, 0xff)
+
+import os
 import re
 import capstone
 
@@ -51,6 +58,7 @@ class GadFinder:
     def find(self, filenames: list[str], base=None, badchars=None) -> list[Gadget]:
         ''' base is normalised to one entry per binary by the argument parser '''
         bases = base if isinstance(base, list) else [base] * len(filenames)
+        avoid = self._avoid_bytes(badchars)
 
         if not self._keep_duplicates():
             seen: dict = {}
@@ -60,20 +68,42 @@ class GadFinder:
                 total = 0
                 for gadget in self._search_gadgets(binary, badchars):
                     total += 1
-                    if gadget in seen:
-                        seen[gadget].count += 1
-                    else:
+                    existing = seen.get(gadget)
+                    if existing is None:
                         gadget.count = 1
                         seen[gadget] = gadget
+                    else:
+                        existing.count += 1
+                        ''' Among duplicates, keep the address with the fewest
+                            terminator canary bytes (see issue #5) '''
+                        if self._avoid_canary() and \
+                                self._addr_canary_score(gadget, avoid) < self._addr_canary_score(existing, avoid):
+                            gadget.count = existing.count
+                            seen[gadget] = gadget
                 unique = len(seen) - before
                 debug.info(f'{unique} unique gadgets ({total - unique} duplicates discarded)')
-            return list(seen.values())
+            return self._sort_gadgets(list(seen.values()))
         else:
             gadgets = []
             for filename, file_base in zip(filenames, bases):
                 binary = self._open_binary(filename, file_base)
                 gadgets.extend(self._search_gadgets(binary, badchars))
-            return gadgets
+            return self._sort_gadgets(gadgets)
+
+    def _avoid_bytes(self, badchars) -> set:
+        ''' Bytes to avoid in gadget addresses when deduplicating: the
+            user-supplied bad chars if any, else the default canary bytes. '''
+        if badchars:
+            return {int(badchar, 0) for badchar in badchars}
+        return set(CANARY_BYTES)
+
+    def _addr_canary_score(self, gadget: Gadget, avoid: set) -> int:
+        ''' Number of bytes to avoid present in the gadget's packed address '''
+        packed = utils.pack_addr(gadget.vaddr, gadget.mode)
+        return sum(byte in avoid for byte in packed)
+
+    def _sort_gadgets(self, gadgets: list[Gadget]) -> list[Gadget]:
+        return sorted(gadgets, key=lambda g: (os.path.basename(g.filename), g.vaddr))
 
     def _open_binary(self, filename, base):
         binary = rop3.binary.Binary(filename, base)
@@ -167,6 +197,9 @@ class GadFinder:
 
     def _keep_duplicates(self):
         return self.flags & KEEP_DUPLICATES
+
+    def _avoid_canary(self):
+        return self.flags & AVOID_CANARY
 
     def _is_valid_gadget(self, decodes):
         ''' Invalid instructions and, thus, not decoded '''

--- a/rop3/parsers/yaml_parser.py
+++ b/rop3/parsers/yaml_parser.py
@@ -54,7 +54,7 @@ class YamlParser:
         return ret
 
     def _get_op_files(self):
-        return [filename for filename in glob.glob(os.path.join(self.folder, '*.yaml'), recursive=True) if os.path.isfile(filename)]
+        return [filename for filename in glob.glob(os.path.join(self.folder, '**', '*.yaml'), recursive=True) if os.path.isfile(filename)]
 
     def _read_yaml(self, filename):
         with open(filename, 'r') as f:


### PR DESCRIPTION
## Summary

Implements the enhancement requested in #5 and bundles a few quality-of-life fixes found while reviewing the new version.

### Closes #5 — terminator canary bytes in addresses
When discarding duplicate gadgets (the default mode), keep the address with the **fewest terminator canary bytes** (`0x00`, `0x0a`, `0x0d`, `0xff`, or the user-supplied `--badchar` set). This makes the displayed address more likely to be usable in exploits that go through `strcpy()`/`gets()`-style sinks.

- The gadget **set is unchanged** — only the address representative shown for each unique gadget is improved.
- New `--keep-canary-address` flag opts out and restores the previous first-seen behaviour.

### Quality-of-life fixes
- **Deterministic output**: gadgets are now sorted by `(filename, address)`.
- **32-bit register names**: `normalize_reg` is mode-aware, so side effects on 32-bit binaries display 32-bit names (`eax`, `ebp`) instead of 64-bit (`rax`, `rbp`).
- **Recursive op loading**: the ROPLang glob is now actually recursive (`**/*.yaml`), so operations can be organised in subdirectories.
- **Mach-O**: pick the first supported slice robustly in fat binaries (do not commit to an unrecognised header), and scan every code section (e.g. `__stubs`, `__stub_helper`) instead of only `__text`.

## Testing
- Mach-O `/bin/ls` (x64): 67 → 71 gadgets (extra code sections), output sorted.
- busybox x86 (32-bit, extracted from `i386/busybox`): 2417 gadgets, side effects shown as `esi/ebx/edx` with no 64-bit name leak.
- Canary dedup verified both as a unit and end-to-end through `find()`: prefers the canary-free address while preserving `count`.
- `get_ops` loads all 23 ops via the recursive glob; `--op`, composites, `--badchar`, `--help`, `--version` all OK with no regression vs. baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)