### PR TITLE
Fix --base for ELF/Mach-O, ANSI on non-TTY output, and address-mode guards

### DIFF
--- a/rop3/binaries/elf.py
+++ b/rop3/binaries/elf.py
@@ -35,6 +35,7 @@ class ELF:
             file = io.BytesIO(data)
             self._elf = ELFFile(file)
             self._arch = self._parse_arch()
+            self._base_delta = self._base_delta_for(base)
         except ELFError as exc:
             raise binary.BinaryException(str(exc)) from exc
 
@@ -47,6 +48,20 @@ class ELF:
         raise binary.BinaryException(
             'ELF: Unsupported architecture type')
 
+    def _image_base(self):
+        ''' Position-independent images (ET_DYN: PIE/shared objects) are
+            linked at 0; ET_EXEC uses the lowest loadable segment address '''
+        if self._elf.header.e_type == 'ET_DYN':
+            return 0
+        loads = [seg['p_vaddr'] for seg in self._elf.iter_segments()
+                 if seg['p_type'] == 'PT_LOAD']
+        return min(loads) if loads else 0
+
+    def _base_delta_for(self, base):
+        if not base:
+            return 0
+        return int(base, 0) - self._image_base()
+
     def get_exec_sections(self):
         ret = []
 
@@ -54,7 +69,7 @@ class ELF:
             ''' SHF_EXECINSTR means section contains executable code '''
             if sec.header.sh_flags & SHF_EXECINSTR:
                 ret.append({
-                    'vaddr': sec.header.sh_addr,
+                    'vaddr': sec.header.sh_addr + self._base_delta,
                     'opcodes': sec.data()
                 })
         return ret

--- a/rop3/binaries/macho.py
+++ b/rop3/binaries/macho.py
@@ -62,6 +62,25 @@ class MachO:
             raise binary.BinaryException(
                     'Mach-O: No supported architectures were found')
 
+        self._base_delta = self._base_delta_for(base)
+
+    def _image_base(self):
+        ''' Link-time base of the image: the __TEXT segment vmaddr (fall back
+            to the lowest segment vmaddr) '''
+        vmaddrs = []
+        for (lc, cmd, data) in self._header.commands:
+            if lc.cmd in (LC_SEGMENT, LC_SEGMENT_64):
+                segname = cmd.segname.decode('utf-8').strip('\x00')
+                if segname == '__TEXT':
+                    return cmd.vmaddr
+                vmaddrs.append(cmd.vmaddr)
+        return min(vmaddrs) if vmaddrs else 0
+
+    def _base_delta_for(self, base):
+        if not base:
+            return 0
+        return int(base, 0) - self._image_base()
+
     def get_exec_sections(self):
         ret = []
         for (lc, cmd, data) in self._header.commands:
@@ -78,7 +97,7 @@ class MachO:
                         self._file.seek(offset + section.offset)
                         section_data = self._file.read(section.size)
                         ret.append({
-                            'vaddr': section.addr,
+                            'vaddr': section.addr + self._base_delta,
                             'opcodes': section_data
                         })
         return ret

--- a/rop3/gadget.py
+++ b/rop3/gadget.py
@@ -20,9 +20,17 @@ from dataclasses import dataclass, field
 from rop3.arch import arch_singleton
 
 import os
+import sys
 
 WARNING_COLOR = '\033[93m'
 END_COLOR = '\033[0m'
+
+def _colorize(text: str) -> str:
+    ''' Wrap text in the warning color only when writing to a terminal and
+        NO_COLOR is unset, so redirected/piped output stays clean. '''
+    if sys.stdout.isatty() and not os.environ.get('NO_COLOR'):
+        return f'{WARNING_COLOR}{text}{END_COLOR}'
+    return text
 
 @dataclass
 class Gadget:
@@ -100,7 +108,8 @@ class Gadget:
             ret += f" (x{self.count})"
         side_regs = list(self.side_regs)
         if len(side_regs) > 0:
-            ret += f" {WARNING_COLOR}(modifies {', '.join(side_regs)}){END_COLOR}"
+            modifies = ', '.join(side_regs)
+            ret += f" {_colorize(f'(modifies {modifies})')}"
 
         return ret
 

--- a/rop3/utils.py
+++ b/rop3/utils.py
@@ -71,6 +71,8 @@ def pretty_addr(addr, mode=capstone.CS_MODE_64):
         padding = 8
     elif mode == capstone.CS_MODE_64:
         padding = 16
+    else:
+        raise ValueError(f'unsupported mode: {mode}')
 
     return f'{int(addr):#0{padding}x}'
 
@@ -79,6 +81,8 @@ def pack_addr(addr, mode=capstone.CS_MODE_64):
         formater = '<I'
     elif mode == capstone.CS_MODE_64:
         formater = '<Q'
+    else:
+        raise ValueError(f'unsupported mode: {mode}')
 
     return struct.pack(formater, addr)
 


### PR DESCRIPTION
Fixes the three bugs found during the post-merge code review.

### Closes #13 — `--base` now works for ELF and Mach-O
Previously `--base` was applied only for PE; ELF and Mach-O accepted it and silently ignored it. The base is treated as the new image base and addresses are shifted by `base - image_base`:
- ELF: image base is `0` for PIE/`ET_DYN`, the lowest `PT_LOAD` vaddr for `ET_EXEC`.
- Mach-O: image base is the `__TEXT` segment vmaddr (fallback: lowest segment vmaddr).

```
# ELF PIE (busybox), --base 0xdead0000
[bb32 @ 0xdead701b]: add esp, 8 ; pop ebx ; ret
# Mach-O /bin/ls, --base 0x140000000 (img base 0x100000000)
0x100000775 -> 0x140000775   # same gadget, shifted by 0x40000000
```

### Closes #14 — no ANSI escapes on non-TTY output
`Gadget.__str__` now colorizes the side-effect list only when `stdout.isatty()` and `NO_COLOR` is unset, so `rop3.py ... > out.txt` / pipes stay clean. Verified: piped `--op` output shows `(modifies ...)` with no escape sequences; on a TTY the color is preserved.

### Closes #15 — address helpers guard unknown modes
`pretty_addr`/`pack_addr` now raise `ValueError(f'unsupported mode: {mode}')` instead of referencing an unbound local when the capstone mode is neither 32- nor 64-bit.

## Testing
- ELF (busybox x86) and Mach-O (`/bin/ls` x64) rebasing verified end-to-end.
- ANSI gating verified both end-to-end (piped) and as a unit (TTY / `NO_COLOR`).
- `pretty_addr`/`pack_addr` raise on an unsupported mode.
- Smoke: `--version`, plain listing and `--op` unaffected (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)