### PR TITLE
Add --arch, machine-readable output, byte bad-chars and symbol annotation (#19-#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Now, you can install dependencies in [requirements.txt](requirements.txt):
 
 ```
 usage: rop3.py [-h] [-v] [--depth <bytes>] [--all] [--rop | --no-rop] [--retf | --no-retf] [--jop | --no-jop] [--allow-undeterministic-gadgets] [--allow-complex-memory-ops] [--verbose]
-               [--binary <file> [<file> ...]] [--badchar <hex> [<hex> ...]] [--keep-canary-address] [--base <hex> [<hex> ...]] [--op <op>] [--dst <reg>] [--src <reg>] [--ropchain <file>]
-               [--exhaustive | --no-exhaustive]
+               [--binary <file> [<file> ...]] [--badchar <hex> [<hex> ...]] [--badchar-bytes <hex> [<hex> ...]] [--keep-canary-address] [--base <hex> [<hex> ...]] [--arch <name>] [--symbols]
+               [--output {text,json,csv}] [--op <op>] [--dst <reg>] [--src <reg>] [--ropchain <file>] [--exhaustive | --no-exhaustive]
 
 This tool allows you to search for gadgets, operations, and ROP chains using a backtracking algorithm in a tree-like structure
 
@@ -56,10 +56,16 @@ options:
                         specify a list of binary path files to analyze
   --badchar <hex> [<hex> ...]
                         specify a list of chars to avoid in gadget address
+  --badchar-bytes <hex> [<hex> ...]
+                        specify a list of chars to avoid in gadget opcode bytes
   --keep-canary-address
                         do not prefer canary-free addresses (0x00, 0x0a, 0x0d, 0xff) when discarding duplicate gadgets
   --base <hex> [<hex> ...]
                         specify a base address to relocate binary files (it may take a while). When you specify more than one base address, you need to provide one address for each binary
+  --arch <name>         select the architecture slice of a fat Mach-O binary (e.g. x86_64, i386)
+  --symbols             annotate gadgets with the nearest symbol (when the binary is not stripped)
+  --output {text,json,csv}
+                        output format (default: text)
   --op <op>             search for operation
   --dst <reg>           specify a destination register for the operation
   --src <reg>           specify a source register for the operation

--- a/rop3/__init__.py
+++ b/rop3/__init__.py
@@ -41,25 +41,30 @@ def main():
             if args.ropchain:
                 ropchain = rop3.ropchain.RopChain(finder)
                 result = ropchain.search_from_files(args.binary, args.ropchain,
-                                         base=args.base, badchars=args.badchar)
-                if args.exhaustive:
-                    for idx, x in enumerate(result, 1):
-                        utils.print_ropchain(x, idx)
-                else:
-                    utils.print_ropchain(next(iter(result)))
+                                         base=args.base, badchars=args.badchar,
+                                         badchar_bytes=args.badchar_bytes,
+                                         arch=args.arch, symbols=args.symbols)
+                utils.output_ropchains(result, args.output, exhaustive=args.exhaustive)
             elif args.op:
-
-                result = finder.find_op(args.binary, args.op, args.dst, args.src, base=args.base, badchars=args.badchar)
+                result = finder.find_op(args.binary, args.op, args.dst, args.src,
+                                        base=args.base, badchars=args.badchar,
+                                        badchar_bytes=args.badchar_bytes,
+                                        arch=args.arch, symbols=args.symbols)
                 if result and isinstance(result[0], list):
-                    for chain in result:
-                        for gadget in chain:
-                            utils.print_gadget(gadget)
+                    ''' Composite operation: a list of chains '''
+                    if args.output == 'text':
+                        for chain in result:
+                            for gadget in chain:
+                                utils.print_gadget(gadget)
+                    else:
+                        utils.output_ropchains(result, args.output, exhaustive=True)
                 else:
-                    for gadget in result:
-                        utils.print_gadget(gadget)
+                    utils.output_gadgets(result, args.output)
             else:
-                for gadget in finder.find(args.binary, base=args.base, badchars=args.badchar):
-                    utils.print_gadget(gadget)
+                gadgets = finder.find(args.binary, base=args.base, badchars=args.badchar,
+                                      badchar_bytes=args.badchar_bytes,
+                                      arch=args.arch, symbols=args.symbols)
+                utils.output_gadgets(gadgets, args.output)
         except parser.ParserException as exc:
             debug.error(str(exc))
         except rop3.ropchain.RopChainNotFound as exc:

--- a/rop3/args.py
+++ b/rop3/args.py
@@ -39,8 +39,12 @@ class ArgumentParser:
         self.argparser.add_argument('--verbose', action='store_true', default=False, help='show progress information (gadget counts, combinations)')
         self.argparser.add_argument('--binary', type=str, metavar='<file>', nargs='+', help='specify a list of binary path files to analyze')
         self.argparser.add_argument('--badchar', type=str, metavar='<hex>', nargs='+', help='specify a list of chars to avoid in gadget address')
+        self.argparser.add_argument('--badchar-bytes', type=str, metavar='<hex>', nargs='+', help='specify a list of chars to avoid in gadget opcode bytes')
         self.argparser.add_argument('--keep-canary-address', action='store_true', default=False, help='do not prefer canary-free addresses (0x00, 0x0a, 0x0d, 0xff) when discarding duplicate gadgets')
         self.argparser.add_argument('--base', type=str, metavar='<hex>', nargs='+', help='specify a base address to relocate binary files (it may take a while). When you specify more than one base address, you need to provide one address for each binary')
+        self.argparser.add_argument('--arch', type=str, metavar='<name>', default=None, help='select the architecture slice of a fat Mach-O binary (e.g. x86_64, i386)')
+        self.argparser.add_argument('--symbols', action='store_true', default=False, help='annotate gadgets with the nearest symbol (when the binary is not stripped)')
+        self.argparser.add_argument('--output', choices=['text', 'json', 'csv'], default='text', help='output format (default: text)')
         self.argparser.add_argument('--op', type=str, metavar='<op>', help='search for operation')
         self.argparser.add_argument('--dst', type=str, metavar='<reg>', help='specify a destination register for the operation')
         self.argparser.add_argument('--src', type=str, metavar='<reg>', help='specify a source register for the operation')
@@ -108,8 +112,10 @@ class ArgumentParser:
             for baddr in args.base:
                 self._check_int_value(baddr)
 
-        if args.badchar:
-            for badchar in args.badchar:
+        for option in (args.badchar, args.badchar_bytes):
+            if not option:
+                continue
+            for badchar in option:
                 value = self._check_int_value(badchar)
                 if value < 0x00 or value > 0xff:
                     debug.error(f'{badchar}: bad char must be one byte (range 0x00-0xff)')

--- a/rop3/binaries/elf.py
+++ b/rop3/binaries/elf.py
@@ -19,6 +19,7 @@ import capstone
 import io
 
 from elftools.elf.elffile import ELFFile, ELFError
+from elftools.elf.sections import SymbolTableSection
 
 import rop3.binary as binary
 
@@ -72,6 +73,19 @@ class ELF:
                     'vaddr': sec.header.sh_addr + self._base_delta,
                     'opcodes': sec.data()
                 })
+        return ret
+
+    def get_symbols(self):
+        ''' Function/object symbols from .symtab and .dynsym, rebased by the
+            same delta as the sections. Stripped binaries yield none. '''
+        ret = []
+        for sec in self._elf.iter_sections():
+            if not isinstance(sec, SymbolTableSection):
+                continue
+            for sym in sec.iter_symbols():
+                addr = sym['st_value']
+                if sym.name and addr:
+                    ret.append((addr + self._base_delta, sym.name))
         return ret
 
     def get_arch(self):

--- a/rop3/binaries/macho.py
+++ b/rop3/binaries/macho.py
@@ -17,11 +17,12 @@ along with rop3. If not, see <https://www.gnu.org/licenses/>.
 
 import capstone
 import io
+import struct
 
 from macholib.MachO import MachO as _MachO
 from macholib.mach_o import (
-    LC_SEGMENT, LC_SEGMENT_64,
-    CPU_TYPE_NAMES,
+    LC_SEGMENT, LC_SEGMENT_64, LC_SYMTAB,
+    CPU_TYPE_NAMES, N_STAB,
     S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS
 )
 
@@ -32,8 +33,14 @@ from rop3.archs.x86_arch import X86_Architecture, X64_Architecture
 VM_PROT_EXECUTE = 0x04
 S_INSTRUCTION_ATTRS = S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS
 
+# Mach-O architecture name -> (rop3 architecture class)
+SUPPORTED_ARCHS = {
+    'x86_64': X64_Architecture,
+    'i386': X86_Architecture,
+}
+
 class MachO:
-    def __init__(self, data, base):
+    def __init__(self, data, base, arch=None):
         # Dirty way to initialize the class, since it only supports reading
         # from a filename
         try:
@@ -46,23 +53,41 @@ class MachO:
             self._macho.load(self._file)
         except Exception as exc:
             raise binary.BinaryException(str(exc)) from exc
-        # Fat binaries carry several headers; pick the first supported slice
-        # (do not commit to a header until its architecture is recognised)
-        self._header = None
-        self._arch = None
-        for header in self._macho.headers:
-            arch = CPU_TYPE_NAMES.get(header.header.cputype)
-            if arch == "x86_64":
-                self._header, self._arch = header, X64_Architecture()
-                break
-            elif arch == "i386":
-                self._header, self._arch = header, X86_Architecture()
-                break
-        if not self._header:
-            raise binary.BinaryException(
-                    'Mach-O: No supported architectures were found')
+
+        self._header, self._arch = self._select_slice(arch)
 
         self._base_delta = self._base_delta_for(base)
+
+    def _select_slice(self, arch):
+        '''
+        Fat binaries carry several headers. With --arch, pick that slice; else
+        pick the first supported slice in file order. Do not commit to a header
+        until its architecture is recognized.
+        '''
+        available = {}   # arch name -> header (first occurrence)
+        for header in self._macho.headers:
+            name = CPU_TYPE_NAMES.get(header.header.cputype)
+            if name is not None:
+                available.setdefault(name, header)
+
+        if arch is not None:
+            if arch not in SUPPORTED_ARCHS:
+                raise binary.BinaryException(
+                    f'Mach-O: unsupported --arch {arch} '
+                    f'(choose from {", ".join(sorted(SUPPORTED_ARCHS))})')
+            if arch not in available:
+                present = ", ".join(sorted(available)) or "none"
+                raise binary.BinaryException(
+                    f'Mach-O: arch {arch} not present in binary (available: {present})')
+            return available[arch], SUPPORTED_ARCHS[arch]()
+
+        for header in self._macho.headers:
+            name = CPU_TYPE_NAMES.get(header.header.cputype)
+            if name in SUPPORTED_ARCHS:
+                return header, SUPPORTED_ARCHS[name]()
+
+        raise binary.BinaryException(
+                'Mach-O: No supported architectures were found')
 
     def _image_base(self):
         ''' Link-time base of the image: the __TEXT segment vmaddr (fall back
@@ -100,6 +125,36 @@ class MachO:
                             'vaddr': section.addr + self._base_delta,
                             'opcodes': section_data
                         })
+        return ret
+
+    def get_symbols(self):
+        ''' Symbols from the LC_SYMTAB symbol table, rebased by the same delta
+            as the sections. macholib does not expand the nlist array, so it is
+            parsed here from the file. Stripped binaries yield none. '''
+        ret = []
+        is64 = self._arch.mode == capstone.CS_MODE_64
+        entry_fmt = '<IBBHQ' if is64 else '<IBBhI'   # nlist_64 / nlist
+        entry_size = struct.calcsize(entry_fmt)
+        slice_off = self._header.offset
+
+        for (lc, cmd, data) in self._header.commands:
+            if lc.cmd != LC_SYMTAB:
+                continue
+            self._file.seek(slice_off + cmd.stroff)
+            strtab = self._file.read(cmd.strsize)
+            self._file.seek(slice_off + cmd.symoff)
+            entries = self._file.read(cmd.nsyms * entry_size)
+            for i in range(cmd.nsyms):
+                n_strx, n_type, n_sect, n_desc, n_value = struct.unpack_from(
+                    entry_fmt, entries, i * entry_size)
+                if n_type & N_STAB:          # debug (STABS) entry
+                    continue
+                if not n_value:              # undefined / no address
+                    continue
+                end = strtab.find(b'\x00', n_strx)
+                name = strtab[n_strx:end].decode('utf-8', 'replace')
+                if name:
+                    ret.append((n_value + self._base_delta, name))
         return ret
 
     def get_arch(self):

--- a/rop3/binaries/pe.py
+++ b/rop3/binaries/pe.py
@@ -59,6 +59,22 @@ class PE:
                 })
         return ret
 
+    def get_symbols(self):
+        ''' Best-effort symbols from the export table (names + ordinals),
+            relative to the (possibly relocated) image base. '''
+        ret = []
+        self._pe.parse_data_directories()
+        export_dir = getattr(self._pe, 'DIRECTORY_ENTRY_EXPORT', None)
+        if export_dir is None:
+            return ret
+        image_base = self._pe.OPTIONAL_HEADER.ImageBase
+        for exp in export_dir.symbols:
+            if exp.address:
+                name = exp.name.decode('utf-8', 'replace') if exp.name \
+                    else f'ordinal_{exp.ordinal}'
+                ret.append((image_base + exp.address, name))
+        return ret
+
     def get_arch(self):
         return self._arch
 

--- a/rop3/binary.py
+++ b/rop3/binary.py
@@ -26,10 +26,10 @@ class Binary:
     '''
     Interface to access binary file details
     '''
-    def __init__(self, filename, base):
+    def __init__(self, filename, base, arch=None):
         self.filename = os.path.realpath(filename)
         self.raw_data = self._read_binary()
-        self._binary = self._load_binary(base)
+        self._binary = self._load_binary(base, arch)
 
     def _read_binary(self):
         try:
@@ -38,7 +38,7 @@ class Binary:
         except (IOError, FileNotFoundError):
             debug.error(f'{self.filename}: Unable to read file')
 
-    def _load_binary(self, base):
+    def _load_binary(self, base, arch=None):
         # MS-DOS Stub (PE)
         if self.raw_data[:2] == b'\x4d\x5a':    # MZ
             return pe.PE(self.raw_data, base)
@@ -53,7 +53,7 @@ class Binary:
             b'\xfe\xed\xfa\xcf', b'\xcf\xfa\xed\xfe', # 64-bit
             b'\xca\xfe\xba\xbe', # Fat header
         ]:
-            return macho.MachO(self.raw_data, base)
+            return macho.MachO(self.raw_data, base, arch)
 
         else:
             raise BinaryException(f'{self.filename}: Format file not supported')
@@ -70,6 +70,14 @@ class Binary:
         @returns computer architecture, e.g: x86
         '''
         return self._binary.get_arch()
+
+    def get_symbols(self):
+        '''
+        @returns a list of (address, name) tuples for the binary's symbols,
+        or an empty list when the format/loader has none (e.g. stripped)
+        '''
+        getter = getattr(self._binary, 'get_symbols', None)
+        return getter() if getter else []
 
 class BinaryException(Exception):
     pass

--- a/rop3/gadfinder.py
+++ b/rop3/gadfinder.py
@@ -17,6 +17,7 @@ along with rop3. If not, see <https://www.gnu.org/licenses/>.
 
 import os
 import re
+import bisect
 import capstone
 
 import rop3.utils as utils
@@ -55,18 +56,20 @@ class GadFinder:
         self.depth = depth
         self.flags = flags
 
-    def find(self, filenames: list[str], base=None, badchars=None) -> list[Gadget]:
-        ''' base is normalised to one entry per binary by the argument parser '''
+    def find(self, filenames: list[str], base=None, badchars=None,
+             badchar_bytes=None, arch=None, symbols=False) -> list[Gadget]:
+        ''' base is normalized to one entry per binary by the argument parser '''
         bases = base if isinstance(base, list) else [base] * len(filenames)
         avoid = self._avoid_bytes(badchars)
 
         if not self._keep_duplicates():
             seen: dict = {}
             for filename, file_base in zip(filenames, bases):
-                binary = self._open_binary(filename, file_base)
+                binary = self._open_binary(filename, file_base, arch)
+                symtab = self._symbol_table(binary) if symbols else None
                 before = len(seen)
                 total = 0
-                for gadget in self._search_gadgets(binary, badchars):
+                for gadget in self._search_gadgets(binary, badchars, badchar_bytes, symtab):
                     total += 1
                     existing = seen.get(gadget)
                     if existing is None:
@@ -86,8 +89,9 @@ class GadFinder:
         else:
             gadgets = []
             for filename, file_base in zip(filenames, bases):
-                binary = self._open_binary(filename, file_base)
-                gadgets.extend(self._search_gadgets(binary, badchars))
+                binary = self._open_binary(filename, file_base, arch)
+                symtab = self._symbol_table(binary) if symbols else None
+                gadgets.extend(self._search_gadgets(binary, badchars, badchar_bytes, symtab))
             return self._sort_gadgets(gadgets)
 
     def _avoid_bytes(self, badchars) -> set:
@@ -105,16 +109,34 @@ class GadFinder:
     def _sort_gadgets(self, gadgets: list[Gadget]) -> list[Gadget]:
         return sorted(gadgets, key=lambda g: (os.path.basename(g.filename), g.vaddr))
 
-    def _open_binary(self, filename, base):
-        binary = rop3.binary.Binary(filename, base)
-        arch = binary.get_arch()
-        if arch_singleton.is_initialized() and not arch_singleton.matches(arch):
+    def _open_binary(self, filename, base, arch=None):
+        binary = rop3.binary.Binary(filename, base, arch)
+        binary_arch = binary.get_arch()
+        if arch_singleton.is_initialized() and not arch_singleton.matches(binary_arch):
             debug.error(f'{filename}: mixing architectures (x86/x64) in a single run is not supported')
-        arch_singleton.initialize(arch)
+        arch_singleton.initialize(binary_arch)
         return binary
 
-    def find_op(self, filenames, op, dst=None, src=None, base=None, badchars=None):
-        gadgets = self.find(filenames, base, badchars)
+    def _symbol_table(self, binary):
+        ''' Sorted (address, name) pairs and a parallel address list for the
+            nearest-symbol bisect (see _nearest_symbol). '''
+        symbols = sorted(binary.get_symbols())
+        addrs = [addr for addr, _ in symbols]
+        return (addrs, symbols)
+
+    def _nearest_symbol(self, vaddr, symbol_table):
+        ''' Name (with byte offset) of the closest symbol at or below vaddr. '''
+        addrs, symbols = symbol_table
+        idx = bisect.bisect_right(addrs, vaddr) - 1
+        if idx < 0:
+            return None
+        sym_addr, name = symbols[idx]
+        offset = vaddr - sym_addr
+        return f'{name}+{hex(offset)}' if offset else name
+
+    def find_op(self, filenames, op, dst=None, src=None, base=None,
+                badchars=None, badchar_bytes=None, arch=None, symbols=False):
+        gadgets = self.find(filenames, base, badchars, badchar_bytes, arch, symbols)
         return self.find_op_from_gadgets(gadgets, op, dst, src)
 
     def find_op_from_gadgets(self, gadgets, op, dst=None, src=None):
@@ -132,7 +154,7 @@ class GadFinder:
         op_obj = operation.Operation(op, dst, src)
         return op_obj.filter_gadgets(gadgets)
 
-    def _search_gadgets(self, binary, badchars):
+    def _search_gadgets(self, binary, badchars, badchar_bytes=None, symbol_table=None):
         sections = binary.get_exec_sections()
         arch = arch_singleton.arch.arch
         mode = arch_singleton.arch.mode
@@ -155,15 +177,20 @@ class GadFinder:
                         vaddr = sec_vaddr + ref - depth
                         if self._is_valid_address(vaddr, badchars, mode):
                             bytes_ = sec_opcodes[ref - depth:ref]
+                            if not self._is_valid_bytes(bytes_, badchar_bytes):
+                                continue
                             decodes = list(md.disasm(bytes_, vaddr))
                             if self._is_valid_gadget(decodes):
+                                symbol = self._nearest_symbol(vaddr, symbol_table) \
+                                    if symbol_table else None
                                 yield Gadget(
                                     filename=binary.filename,
                                     arch=arch,
                                     mode=mode,
                                     vaddr=vaddr,
                                     decodes=decodes,
-                                    bytes=bytes_
+                                    bytes=bytes_,
+                                    symbol=symbol,
                                 )
 
     def _gad_terminations(self):
@@ -227,6 +254,14 @@ class GadFinder:
             return True
 
         vaddr = utils.pack_addr(vaddr, arch_mode)
-        
+
         return not any([bytes([int(badchar, 0)]) in vaddr for badchar in badchars])
+
+    def _is_valid_bytes(self, gadget_bytes, badchar_bytes):
+        ''' Reject gadgets whose opcode bytes contain a forbidden byte (#21). '''
+        if not badchar_bytes:
+            return True
+
+        forbidden = {int(b, 0) for b in badchar_bytes}
+        return not any(byte in forbidden for byte in gadget_bytes)
 

--- a/rop3/gadget.py
+++ b/rop3/gadget.py
@@ -45,6 +45,7 @@ class Gadget:
     op: str = None
     dst: str = None
     src: str = None
+    symbol: str = None
     side_regs: set[str] = field(init=False, default_factory=set)
     side_mem: set[str] = field(init=False, default_factory=set)
 
@@ -104,6 +105,8 @@ class Gadget:
     def __str__(self) -> str:
         ret = f"[{os.path.basename(self.filename)} @ {hex(self.vaddr)}]: "
         ret += self.text_repr
+        if self.symbol:
+            ret += f" <{self.symbol}>"
         if self.count and self.count > 1:
             ret += f" (x{self.count})"
         side_regs = list(self.side_regs)
@@ -112,6 +115,24 @@ class Gadget:
             ret += f" {_colorize(f'(modifies {modifies})')}"
 
         return ret
+
+    def to_dict(self) -> dict:
+        ''' Serializable representation for machine-readable output. '''
+        return {
+            'file': os.path.basename(self.filename),
+            'vaddr': hex(self.vaddr),
+            'gadget': self.text_repr,
+            'instructions': [
+                f'{d.mnemonic} {d.op_str}'.strip() for d in self.decodes
+            ],
+            'bytes': self.bytes.hex() if self.bytes is not None else None,
+            'count': self.count,
+            'symbol': self.symbol,
+            'op': self.op,
+            'dst': self.dst,
+            'src': self.src,
+            'modifies': sorted(self.side_regs),
+        }
 
 def heuristic_basic_count(gadget: "Gadget") -> int:
     """

--- a/rop3/ropchain.py
+++ b/rop3/ropchain.py
@@ -52,8 +52,10 @@ class RopChain:
     def __init__(self, gadfinder):
         self.gadfinder = gadfinder
 
-    def search_from_files(self, binaries: list[str], ropfile, base=None, badchars=None) -> Iterator[list[Gadget]]:
-        gadgets = self.gadfinder.find(binaries, base=base, badchars=badchars)
+    def search_from_files(self, binaries: list[str], ropfile, base=None, badchars=None,
+                          badchar_bytes=None, arch=None, symbols=False) -> Iterator[list[Gadget]]:
+        gadgets = self.gadfinder.find(binaries, base=base, badchars=badchars,
+                                      badchar_bytes=badchar_bytes, arch=arch, symbols=symbols)
         return self.search_from_gadgets(gadgets, ropfile)
 
     def search_from_gadgets(self, gadgets, ropfile) -> Iterator[list[Gadget]]:
@@ -148,7 +150,7 @@ class RopChain:
         Returns an array indexed [comb_idx][step_idx].
 
         Each operation's gadget list is sorted once up front, and the
-        filter+prune result is memoised per (step, req_dst, req_src): different
+        filter+prune result is memoized per (step, req_dst, req_src): different
         combinations frequently request the same concrete registers for a given
         step, so this avoids recomputing the same filtered list repeatedly.
         """
@@ -256,7 +258,7 @@ class Tree:
         """
         Gadgets are the actual rop gadgets present in the binary.
         Returns (combinations, ops_gadgets) where each combination is a flat
-        dict mapping every abstract-register name to a normalised concrete reg.
+        dict mapping every abstract-register name to a normalized concrete reg.
         """
         (state, ops_gadgets, op_pairs) = self._get_initial_state(gadgets)
         combinations = self._traverse(state, op_pairs)

--- a/rop3/utils.py
+++ b/rop3/utils.py
@@ -16,6 +16,9 @@ along with rop3. If not, see <https://www.gnu.org/licenses/>.
 '''
 
 import os
+import sys
+import json
+import csv
 import struct
 import __main__
 import capstone
@@ -62,6 +65,55 @@ def print_ropchain(ropchain, idx=None):
         print(gad)
     if idx is not None:
         print()
+
+# Columns used for the CSV output (list fields are space-joined)
+_CSV_COLUMNS = ['file', 'vaddr', 'gadget', 'bytes', 'count',
+                'symbol', 'op', 'dst', 'src', 'modifies']
+
+def _csv_record(gadget):
+    record = gadget.to_dict()
+    record['modifies'] = ' '.join(record['modifies'])
+    return record
+
+def output_gadgets(gadgets, fmt='text'):
+    ''' Emit a flat list of gadgets in the requested format. '''
+    if fmt == 'json':
+        print(json.dumps([g.to_dict() for g in gadgets], indent=2))
+    elif fmt == 'csv':
+        writer = csv.DictWriter(sys.stdout, fieldnames=_CSV_COLUMNS,
+                                extrasaction='ignore')
+        writer.writeheader()
+        for gadget in gadgets:
+            writer.writerow(_csv_record(gadget))
+    else:
+        for gadget in gadgets:
+            print(gadget)
+
+def output_ropchains(chains, fmt='text', exhaustive=False):
+    ''' Emit ROP chains (each a list of gadgets) in the requested format.
+        For plain text without --exhaustive only the first chain is consumed,
+        preserving the laziness of the search generator. '''
+    if fmt == 'text' and not exhaustive:
+        first = next(iter(chains), None)
+        if first is not None:
+            print_ropchain(first)
+        return
+
+    chains = list(chains)
+    if fmt == 'json':
+        print(json.dumps([[g.to_dict() for g in chain] for chain in chains], indent=2))
+    elif fmt == 'csv':
+        writer = csv.DictWriter(sys.stdout, fieldnames=['chain'] + _CSV_COLUMNS,
+                                extrasaction='ignore')
+        writer.writeheader()
+        for idx, chain in enumerate(chains, 1):
+            for gadget in chain:
+                record = _csv_record(gadget)
+                record['chain'] = idx
+                writer.writerow(record)
+    else:
+        for idx, chain in enumerate(chains, 1):
+            print_ropchain(chain, idx)
 
 def warning_text(text):
     return f'{WARNING_COLOR}{text}{END_COLOR}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,74 +73,104 @@ EM_X86_64 = 62
 ET_EXEC = 2
 ET_DYN = 3
 SHT_PROGBITS = 1
+SHT_SYMTAB = 2
 SHT_STRTAB = 3
 SHF_ALLOC = 0x2
 SHF_EXECINSTR = 0x4
+STB_GLOBAL = 1
+STT_FUNC = 2
 
 
 def build_minimal_elf(elfclass: int, machine: int, text_bytes: bytes,
-                      text_addr: int, e_type: int = ET_DYN) -> bytes:
+                      text_addr: int, e_type: int = ET_DYN, symbols=None) -> bytes:
     '''
     Produce a tiny but valid ELF that pyelftools can parse: an ELF header, a
     `.text` PROGBITS section flagged executable at `text_addr`, and a
-    `.shstrtab`. Enough to exercise architecture detection, executable-section
-    extraction and --base relocation. ET_DYN keeps the image base at 0.
+    `.shstrtab`. With `symbols` (a list of (name, value)), it also emits a
+    `.symtab`/`.strtab` pair. Enough to exercise architecture detection,
+    executable-section extraction, --base relocation and symbol parsing.
+    ET_DYN keeps the image base at 0.
     '''
     is64 = elfclass == 64
-    shstrtab = b'\x00.text\x00.shstrtab\x00'
-    name_text = shstrtab.index(b'.text\x00')
-    name_shstr = shstrtab.index(b'.shstrtab\x00')
+    symbols = symbols or []
+
+    def section(name, stype, flags, addr, offset, size, link=0, entsize=0):
+        if is64:
+            return struct.pack('<IIQQQQIIQQ', name, stype, flags, addr,
+                               offset, size, link, 0, 1, entsize)
+        return struct.pack('<IIIIIIIIII', name, stype, flags, addr,
+                           offset, size, link, 0, 1, entsize)
+
+    def sym(name_off, value):
+        info = (STB_GLOBAL << 4) | STT_FUNC
+        if is64:
+            return struct.pack('<IBBHQQ', name_off, info, 0, 1, value, 0)
+        return struct.pack('<IIIBBH', name_off, value, 0, info, 0, 1)
+
+    sym_size = struct.calcsize('<IBBHQQ' if is64 else '<IIIBBH')
+
+    # Section-header string table (.shstrtab)
+    names = b'\x00'
+    def add_name(s):
+        nonlocal names
+        off = len(names)
+        names += s.encode() + b'\x00'
+        return off
+    name_text = add_name('.text')
+    name_shstr = add_name('.shstrtab')
+    name_symtab = add_name('.symtab') if symbols else 0
+    name_strtab = add_name('.strtab') if symbols else 0
+
+    # Symbol string table (.strtab) and symbol entries
+    strtab = b'\x00'
+    sym_entries = sym(0, 0)   # mandatory null symbol at index 0
+    for sname, value in symbols:
+        off = len(strtab)
+        strtab += sname.encode() + b'\x00'
+        sym_entries += sym(off, value)
 
     ehsize = 64 if is64 else 52
     shentsize = 64 if is64 else 40
-    n_sections = 3  # NULL, .text, .shstrtab
 
+    # Lay out section data blocks after the header
     text_off = ehsize
     shstr_off = text_off + len(text_bytes)
-    shoff = shstr_off + len(shstrtab)
+    cursor = shstr_off + len(names)
+    if symbols:
+        symtab_off = cursor
+        strtab_off = symtab_off + len(sym_entries)
+        cursor = strtab_off + len(strtab)
+    shoff = cursor
 
-    # e_ident
+    n_sections = 5 if symbols else 3   # NULL, .text, .shstrtab[, .symtab, .strtab]
+
     ei_class = 2 if is64 else 1
     e_ident = b'\x7fELF' + bytes([ei_class, 1, 1, 0]) + b'\x00' * 8
+    hdr_fmt = '<HHIQQQIHHHHHH' if is64 else '<HHIIIIIHHHHHH'
+    header = e_ident + struct.pack(
+        hdr_fmt,
+        e_type, machine, 1,            # type, machine, version
+        text_addr,                     # entry
+        0,                             # phoff
+        shoff,                         # shoff
+        0,                             # flags
+        ehsize, 0, 0,                  # ehsize, phentsize, phnum
+        shentsize, n_sections, 2,      # shentsize, shnum, shstrndx (.shstrtab)
+    )
 
-    if is64:
-        header = e_ident + struct.pack(
-            '<HHIQQQIHHHHHH',
-            e_type, machine, 1,            # type, machine, version
-            text_addr,                     # entry
-            0,                             # phoff
-            shoff,                         # shoff
-            0,                             # flags
-            ehsize, 0, 0,                  # ehsize, phentsize, phnum
-            shentsize, n_sections, 2,      # shentsize, shnum, shstrndx
-        )
-    else:
-        header = e_ident + struct.pack(
-            '<HHIIIIIHHHHHH',
-            e_type, machine, 1,
-            text_addr,
-            0,
-            shoff,
-            0,
-            ehsize, 0, 0,
-            shentsize, n_sections, 2,
-        )
-
-    def section64(name, stype, flags, addr, offset, size):
-        return struct.pack('<IIQQQQIIQQ', name, stype, flags, addr,
-                           offset, size, 0, 0, 1, 0)
-
-    def section32(name, stype, flags, addr, offset, size):
-        return struct.pack('<IIIIIIIIII', name, stype, flags, addr,
-                           offset, size, 0, 0, 1, 0)
-
-    section = section64 if is64 else section32
-
-    sections = b''.join([
+    section_headers = [
         section(0, 0, 0, 0, 0, 0),                                       # NULL
         section(name_text, SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR,
                 text_addr, text_off, len(text_bytes)),                   # .text
-        section(name_shstr, SHT_STRTAB, 0, 0, shstr_off, len(shstrtab)), # .shstrtab
-    ])
+        section(name_shstr, SHT_STRTAB, 0, 0, shstr_off, len(names)),    # .shstrtab
+    ]
+    payload = text_bytes + names
+    if symbols:
+        section_headers.append(                                          # .symtab
+            section(name_symtab, SHT_SYMTAB, 0, 0, symtab_off,
+                    len(sym_entries), link=4, entsize=sym_size))
+        section_headers.append(                                          # .strtab
+            section(name_strtab, SHT_STRTAB, 0, 0, strtab_off, len(strtab)))
+        payload += sym_entries + strtab
 
-    return header + text_bytes + shstrtab + sections
+    return header + payload + b''.join(section_headers)

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -24,6 +24,7 @@ from rop3.archs.x86_arch import X86_Architecture, X64_Architecture
 from conftest import build_minimal_elf, EM_386, EM_X86_64, ET_DYN
 
 TEXT = b'\x58\xc3'   # pop rax ; ret
+SYMS = [('funcA', 0x1000), ('funcB', 0x1100)]
 
 
 def test_elf_detects_x64():
@@ -71,3 +72,21 @@ def test_binary_unknown_format_raises(tmp_path):
     path.write_bytes(b'not a real binary header')
     with pytest.raises(binary.BinaryException):
         binary.Binary(str(path), None)
+
+
+def test_elf_get_symbols():
+    data = build_minimal_elf(64, EM_X86_64, TEXT, 0x1000, ET_DYN, symbols=SYMS)
+    assert sorted(elfmod.ELF(data, None).get_symbols()) == \
+        [(0x1000, 'funcA'), (0x1100, 'funcB')]
+
+
+def test_elf_get_symbols_rebased():
+    ''' Symbols shift by the same delta as sections under --base. '''
+    data = build_minimal_elf(64, EM_X86_64, TEXT, 0x1000, ET_DYN, symbols=SYMS)
+    assert sorted(elfmod.ELF(data, '0x400000').get_symbols()) == \
+        [(0x401000, 'funcA'), (0x401100, 'funcB')]
+
+
+def test_elf_no_symbols_when_stripped():
+    data = build_minimal_elf(64, EM_X86_64, TEXT, 0x1000, ET_DYN)
+    assert elfmod.ELF(data, None).get_symbols() == []

--- a/tests/test_gadfinder.py
+++ b/tests/test_gadfinder.py
@@ -43,10 +43,11 @@ def test_addr_canary_score(x86):
 
 
 class _FakeBinary:
-    def __init__(self, vaddr, opcodes, filename='fake'):
+    def __init__(self, vaddr, opcodes, filename='fake', symbols=None):
         self.filename = filename
         self._vaddr = vaddr
         self._opcodes = opcodes
+        self._symbols = symbols or []
 
     def get_exec_sections(self):
         return [{'vaddr': self._vaddr, 'opcodes': self._opcodes}]
@@ -54,11 +55,14 @@ class _FakeBinary:
     def get_arch(self):
         return X86_Architecture()
 
+    def get_symbols(self):
+        return self._symbols
 
-def _run_find(flags, buf, base_vaddr):
+
+def _run_find(flags, buf, base_vaddr, symbols_table=None, **kwargs):
     f = gadfinder.GadFinder(flags=flags)
-    f._open_binary = lambda fn, b: _FakeBinary(base_vaddr, bytes(buf))
-    return f.find(['fake'])
+    f._open_binary = lambda fn, b, arch=None: _FakeBinary(base_vaddr, bytes(buf), symbols=symbols_table)
+    return f.find(['fake'], **kwargs)
 
 
 def test_dedup_prefers_canary_free_address(x86):
@@ -95,3 +99,38 @@ def test_results_sorted_by_address(x86):
     gadgets = _run_find(gadfinder.ROP, buf, base)
     vaddrs = [g.vaddr for g in gadgets]
     assert vaddrs == sorted(vaddrs)
+
+
+def test_badchar_bytes_filters_on_opcode_bytes(x86):
+    ''' Issue #21: reject gadgets whose opcode bytes contain a forbidden byte. '''
+    base = 0x10000
+    buf = bytearray(0x40)
+    buf[0x10] = 0xc3                 # ret  -> bytes c3
+    buf[0x20:0x22] = b'\x5d\xc3'     # pop ebp ; ret -> bytes 5d c3
+    gadgets = _run_find(gadfinder.ROP, buf, base, badchar_bytes=['0x5d'])
+    reprs = {g.text_repr for g in gadgets}
+    assert 'ret' in reprs
+    assert 'pop ebp ; ret' not in reprs
+    assert all(0x5d not in g.bytes for g in gadgets)
+
+
+def test_symbol_annotation(x86):
+    ''' Issue #22: gadgets get the nearest symbol at or below their address. '''
+    base = 0x10000
+    buf = bytearray(0x40)
+    buf[0x10:0x12] = b'\x90\xc3'   # nop ; ret  -> gadget at 0x10010
+    buf[0x30:0x32] = b'\x58\xc3'   # pop eax ; ret -> gadget at 0x10030
+    symbols = [(0x10000, 'start'), (0x10020, 'middle')]
+    gadgets = _run_find(gadfinder.ROP, buf, base, symbols=True, symbols_table=symbols)
+    by_text = {g.text_repr: g.symbol for g in gadgets}
+    assert by_text['nop ; ret'] == 'start+0x10'        # nearest <= 0x10010
+    assert by_text['pop eax ; ret'] == 'middle+0x10'   # nearest <= 0x10030
+
+
+def test_symbol_annotation_exact_address(x86):
+    base = 0x10000
+    buf = bytearray(0x40)
+    buf[0x0] = 0xc3    # ret exactly at symbol address 0x10000
+    gadgets = _run_find(gadfinder.ROP, buf, base, symbols=True,
+                        symbols_table=[(0x10000, 'start')])
+    assert gadgets[0].symbol == 'start'   # no +offset when offset is 0

--- a/tests/test_gadget.py
+++ b/tests/test_gadget.py
@@ -82,3 +82,24 @@ def test_colorize_honors_tty_and_no_color(monkeypatch):
     assert '\033' in gadget_mod._colorize('x')
     monkeypatch.setenv('NO_COLOR', '1')
     assert '\033' not in gadget_mod._colorize('x')
+
+
+def test_to_dict(x64):
+    g = make_gadget(b'\x58\xc3', 0x1000)             # pop rax ; ret
+    g.count = 3
+    g.symbol = 'main+0x4'
+    d = g.to_dict()
+    assert d['file'] == 'test'
+    assert d['vaddr'] == '0x1000'
+    assert d['gadget'] == 'pop rax ; ret'
+    assert d['instructions'] == ['pop rax', 'ret']
+    assert d['bytes'] == '58c3'
+    assert d['count'] == 3
+    assert d['symbol'] == 'main+0x4'
+    assert d['modifies'] == []
+
+
+def test_str_includes_symbol(x64):
+    g = make_gadget(b'\xc3', 0x1000)
+    g.symbol = 'func+0x10'
+    assert '<func+0x10>' in str(g)

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -1,0 +1,59 @@
+'''
+This file is part of rop3 (https://github.com/reverseame/rop3).
+
+rop3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+rop3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with rop3. If not, see <https://www.gnu.org/licenses/>.
+'''
+
+import os
+
+import pytest
+
+import rop3.binaries.macho as machomod
+import rop3.binary as binary
+from rop3.archs.x86_arch import X64_Architecture
+
+# /bin/ls on macOS is a fat Mach-O (x86_64 + arm64e): handy real fixture.
+FAT = '/bin/ls'
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(FAT) or open(FAT, 'rb').read(4) != b'\xca\xfe\xba\xbe',
+    reason='requires a fat Mach-O binary (macOS /bin/ls)')
+
+
+def _data():
+    with open(FAT, 'rb') as f:
+        return f.read()
+
+
+def test_default_slice_is_x86_64():
+    assert isinstance(machomod.MachO(_data(), None).get_arch(), X64_Architecture)
+
+
+def test_explicit_arch_x86_64():
+    assert isinstance(machomod.MachO(_data(), None, 'x86_64').get_arch(), X64_Architecture)
+
+
+def test_unsupported_arch_raises():
+    with pytest.raises(binary.BinaryException):
+        machomod.MachO(_data(), None, 'arm64')
+
+
+def test_absent_arch_raises():
+    with pytest.raises(binary.BinaryException):
+        machomod.MachO(_data(), None, 'i386')   # not present in /bin/ls
+
+
+def test_get_symbols_returns_list():
+    syms = machomod.MachO(_data(), None).get_symbols()
+    assert isinstance(syms, list)
+    assert all(isinstance(a, int) and isinstance(n, str) for a, n in syms)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,72 @@
+'''
+This file is part of rop3 (https://github.com/reverseame/rop3).
+
+rop3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+rop3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with rop3. If not, see <https://www.gnu.org/licenses/>.
+'''
+
+import csv
+import io
+import json
+
+import rop3.utils as utils
+
+from conftest import make_gadget
+
+
+def test_output_gadgets_json(x64, capsys):
+    gadgets = [make_gadget(b'\x58\xc3', 0x1000), make_gadget(b'\x5b\xc3', 0x1010)]
+    utils.output_gadgets(gadgets, 'json')
+    data = json.loads(capsys.readouterr().out)
+    assert [g['vaddr'] for g in data] == ['0x1000', '0x1010']
+    assert data[0]['gadget'] == 'pop rax ; ret'
+
+
+def test_output_gadgets_csv(x64, capsys):
+    gadgets = [make_gadget(b'\x58\xc3', 0x1000)]
+    utils.output_gadgets(gadgets, 'csv')
+    rows = list(csv.DictReader(io.StringIO(capsys.readouterr().out)))
+    assert rows[0]['vaddr'] == '0x1000'
+    assert rows[0]['gadget'] == 'pop rax ; ret'
+    assert rows[0]['bytes'] == '58c3'
+
+
+def test_output_gadgets_text(x64, capsys, monkeypatch):
+    monkeypatch.setattr('sys.stdout.isatty', lambda: False, raising=False)
+    utils.output_gadgets([make_gadget(b'\x58\xc3', 0x1000)], 'text')
+    out = capsys.readouterr().out
+    assert 'pop rax ; ret' in out
+    assert '\033' not in out
+
+
+def test_output_ropchains_json(x64, capsys):
+    chain = [make_gadget(b'\x58\xc3', 0x1000), make_gadget(b'\x5b\xc3', 0x1010)]
+    utils.output_ropchains([chain], 'json', exhaustive=True)
+    data = json.loads(capsys.readouterr().out)
+    assert len(data) == 1 and len(data[0]) == 2
+
+
+def test_output_ropchains_csv_has_chain_index(x64, capsys):
+    chain = [make_gadget(b'\x58\xc3', 0x1000)]
+    utils.output_ropchains([chain], 'csv', exhaustive=True)
+    rows = list(csv.DictReader(io.StringIO(capsys.readouterr().out)))
+    assert rows[0]['chain'] == '1'
+
+
+def test_output_ropchains_text_non_exhaustive_takes_first(x64, capsys):
+    ''' Non-exhaustive text output consumes only the first chain (lazy). '''
+    def gen():
+        yield [make_gadget(b'\x58\xc3', 0x1000)]
+        raise AssertionError('second chain should not be consumed')
+    utils.output_ropchains(gen(), 'text', exhaustive=False)
+    assert 'pop rax ; ret' in capsys.readouterr().out

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,7 +33,7 @@ def test_get_op_unknown_raises(x64):
         parser.Parser().get_op('definitely_not_an_op')
 
 
-def test_composite_op_is_recognised(x64):
+def test_composite_op_is_recognized(x64):
     ''' lsd is a composite (compose:) operation. '''
     resolved = parser.Parser().get_op('lsd')
     assert isinstance(resolved, parser.CompositeOperation)


### PR DESCRIPTION
Implements four enhancements from the backlog.

### #19 — `--arch` slice selection for fat Mach-O
Select which slice of a fat/universal Mach-O to analyse (e.g. `--arch x86_64`, `--arch i386`). Without it, the first supported slice is used (unchanged). Clear errors for an unsupported (`arm64`) or absent slice. Threaded through `Binary` → `MachO`.

### #20 — machine-readable output `--output {text,json,csv}`
Structured output for scripting/pwntools. `Gadget.to_dict()` provides a stable record (`file`, `vaddr`, `gadget`, `instructions`, `bytes`, `count`, `symbol`, `op`, `dst`, `src`, `modifies`). Works for plain gadgets, `--op` results and `--ropchain` (CSV adds a `chain` column). `text` remains the default and the non-exhaustive ropchain path stays lazy.

### #21 — `--badchar-bytes`
Reject gadgets whose **opcode bytes** contain a forbidden byte (the existing `--badchar` still filters the **address** only). Useful when the payload itself travels through a byte-restricted sink.

### #22 — `--symbols`
Annotate each gadget with the nearest symbol at or below its address (`name+offset`). Loaders gained `get_symbols()`:
- ELF: `.symtab` / `.dynsym` via pyelftools.
- Mach-O: `LC_SYMTAB`, parsed from the file (macholib does not expand the nlist array).
- PE: export table via pefile.

All symbol addresses are rebased by the same delta as `--base`.

### Other
- Comments/docstrings switched to American English spelling.

## Testing
- **78 tests pass** on Python 3.11 and 3.13.
- New coverage: byte bad-chars, symbol annotation + nearest-symbol resolution, JSON/CSV output, ELF symbol parsing (the in-memory ELF builder now emits an optional `.symtab`/`.strtab`, so no binary blobs are committed) and Mach-O slice selection (guarded to macOS / fat `/bin/ls`).
- End-to-end verified on `/bin/ls` (Mach-O) and a 32-bit busybox (ELF).
- README usage block updated.

Closes #19, closes #20, closes #21, closes #22.

Generated with [Claude Code](https://claude.com/claude-code)