### PR TITLE
Support hyphenated operations and negative constants in ROPChain parser (#38)

### DIFF
--- a/rop3/ropchain.py
+++ b/rop3/ropchain.py
@@ -39,8 +39,8 @@ mov(reg3,reg2)  -> OP: mov, DST: reg3, SRC: reg2
 mov(reg3, reg2) -> OP: mov, DST: reg3, SRC: reg2
 '''
 REGEX_OP = re.compile(
-    r'^(?P<OP>[a-zA-Z]+)' + \
-    r'\((?P<DST>[a-zA-Z0-9]+)?(, ?(?P<SRC>[a-zA-Z0-9]+))?\)' + \
+    r'^(?P<OP>[a-zA-Z0-9-]+)' + \
+    r'\((?P<DST>[a-zA-Z0-9-]+)?(, ?(?P<SRC>[a-zA-Z0-9-]+))?\)' + \
     r'(?:\s*;.*)?$'
 )
 COMMENT = re.compile(r'^(?:\s*;.*)?$')

--- a/tests/test_ropchain.py
+++ b/tests/test_ropchain.py
@@ -96,6 +96,35 @@ def test_explicit_dst_clears_clobbered_register(x64):
     ]
 
 
+def test_parse_negative_constant_source(x64, tmp_path):
+    '''
+    Regression (#38): a minus sign before a constant (e.g. -1) must be parsed
+    as the source operand. Before the fix REGEX_OP did not allow '-' in an
+    operand and the line failed with "Unable to parse operation".
+    '''
+    ropfile = tmp_path / 'chain.txt'
+    ropfile.write_text('sub(rax, -1)\n')
+    parsed = RopChain(None)._parse_ropfile(str(ropfile))
+    assert len(parsed) == 1
+    assert parsed[0]['op'] == 'sub'
+    assert parsed[0]['dst'] == 'rax'
+    assert parsed[0]['src'] == '-1'
+
+
+def test_parse_hyphenated_operation_name(x64, tmp_path):
+    '''
+    Regression (#38): an operation whose name contains a hyphen (e.g. jmp-rel)
+    must be parsed. Before the fix REGEX_OP did not allow '-' in the operation
+    name and the line failed with "Unable to parse operation". jmp-rel is a
+    composite operation, so it expands into its concrete steps.
+    '''
+    ropfile = tmp_path / 'chain.txt'
+    ropfile.write_text('jmp-rel(rax)\n')
+    parsed = RopChain(None)._parse_ropfile(str(ropfile))
+    assert parsed
+    assert all(op['op'] != 'jmp-rel' for op in parsed)
+
+
 def test_store_dst_does_not_clear_clobbered_address_register(x64):
     '''
     Regression (#36): a store `st(rbx, rax)` is `mov [rbx], rax`, where rbx is


### PR DESCRIPTION
## Summary

Fixes #38. The ROPChain file parser rejected two legitimate cases with `Unable to parse operation`:

- **Hyphenated operation names**, e.g. `jmp-rel` (a real operation defined in `rop3/roplang/jmp-rel.yaml`). `REGEX_OP` limited the operation name to `[a-zA-Z]+`.
- **Negative constant operands**, e.g. `sub(REG1, -1)`. Operands were limited to `[a-zA-Z0-9]+`, so the leading minus sign broke the match. Immediates are parsed downstream via `int(reg, 0)` in `operation.py`, so negatives are otherwise valid.

The fix allows `-` in both the operation name and the operands in `REGEX_OP`, as suggested in the issue.

## Testing

- Added two regression tests in `tests/test_ropchain.py` exercising `_parse_ropfile` end to end:
  - `test_parse_negative_constant_source` — `sub(rax, -1)` parses with `src == '-1'`.
  - `test_parse_hyphenated_operation_name` — `jmp-rel(rax)` parses and expands into its concrete steps.
- Full suite passes: 100 passed, 5 skipped (unrelated macOS Mach-O tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)